### PR TITLE
fixes: uncheck required subcategory option for product

### DIFF
--- a/server/src/products/dto/product.dto.ts
+++ b/server/src/products/dto/product.dto.ts
@@ -100,10 +100,10 @@ export class AddProductDto {
   @IsInt({ each: true })
   categories: number[];
 
-  @IsOptional()
-  @IsArray()
-  @ArrayNotEmpty()
-  @IsInt({ each: true })
+  // @IsOptional()
+  // @IsArray()
+  // @ArrayNotEmpty()
+  // @IsInt({ each: true })
   subcategories: number[];
 
   @IsOptional()

--- a/server/src/products/dto/product.dto.ts
+++ b/server/src/products/dto/product.dto.ts
@@ -100,10 +100,10 @@ export class AddProductDto {
   @IsInt({ each: true })
   categories: number[];
 
-  // @IsOptional()
-  // @IsArray()
+  @IsOptional()
+  @IsArray()
   // @ArrayNotEmpty()
-  // @IsInt({ each: true })
+  @IsInt({ each: true })
   subcategories: number[];
 
   @IsOptional()


### PR DESCRIPTION
This pull request includes a small change to the `server/src/products/dto/product.dto.ts` file. The change involves commenting out the `@ArrayNotEmpty()` decorator in the `AddProductDto` class.

* [`server/src/products/dto/product.dto.ts`](diffhunk://#diff-d8e6edda2ad96716051dc3c4864266edac5b0f299fb99b0e991edd21503807d4L105-R105): Commented out the `@ArrayNotEmpty()` decorator in the `AddProductDto` class.