### PR TITLE
fixes: description in sub cat

### DIFF
--- a/prisma/migrations/20250205044840_description/migration.sql
+++ b/prisma/migrations/20250205044840_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SubCategories" ADD COLUMN     "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model SubCategories {
   id                  Int          @id @default(autoincrement())
   name                String       @unique
   createdAt           DateTime     @default(now())
+  description         String?
   posterImageUrl      String?
   posterImagePublicId String?
   categories          Categories[] @relation("CategorySubCategories")

--- a/src/subcategories/subcategories.service.ts
+++ b/src/subcategories/subcategories.service.ts
@@ -29,7 +29,7 @@ export class SubcategoriesService {
 
     try {
       const { name, posterImageUrl } = categoryData;
-      const { description, categories, categoriesId, ...Data } = categoryData;
+      const {  categories, categoriesId, ...Data } = categoryData;
 
       const existingSubCategory = await this.prisma.subCategories.findFirst({
         where: { name },
@@ -97,7 +97,7 @@ export class SubcategoriesService {
 
   async updateSubCategory(subCategoryData: UpdateSubCategoryDto,userEmail: string) {
     try {
-      const { id, name, categoriesId, posterImageUrl, description, ...Data } =
+      const { id, name, categoriesId, posterImageUrl, ...Data } =
         subCategoryData;
 
       const existingSubCategory = await this.prisma.subCategories.findUnique({


### PR DESCRIPTION
This pull request introduces changes to the `SubCategories` model by adding a new `description` field. The changes span across database migration, schema definition, and service implementation to accommodate the new field.

### Database Migration:
* [`prisma/migrations/20250205044840_description/migration.sql`](diffhunk://#diff-74993a27b48495307f768719b6e0a32d7a2bc1b0de9952206e2a236d72be7792R1-R2): Added a new `description` column to the `SubCategories` table.

### Schema Update:
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR83): Updated the `SubCategories` model to include an optional `description` field.

### Service Implementation:
* [`src/subcategories/subcategories.service.ts`](diffhunk://#diff-9abfbaa972b79560d32be6ae2fdbeecf4f641a80cacc0ad2be742837e607254fL32-R32): Removed the `description` field from the destructuring assignments in the `createSubCategory` and `updateSubCategory` methods to reflect the updated schema. [[1]](diffhunk://#diff-9abfbaa972b79560d32be6ae2fdbeecf4f641a80cacc0ad2be742837e607254fL32-R32) [[2]](diffhunk://#diff-9abfbaa972b79560d32be6ae2fdbeecf4f641a80cacc0ad2be742837e607254fL100-R100)